### PR TITLE
Create wrap definition for mt32emu library

### DIFF
--- a/include/mt32emu/c_interface/meson.build
+++ b/include/mt32emu/c_interface/meson.build
@@ -1,0 +1,3 @@
+foreach file_name, src_file : mt32emu_c_header_map
+  configure_file(input : src_file, output : file_name, copy : true)
+endforeach

--- a/include/mt32emu/meson.build
+++ b/include/mt32emu/meson.build
@@ -1,0 +1,9 @@
+configure_file(input : mt32emu_config_h_in,
+               output : 'config.h',
+               configuration : conf_data)
+
+foreach file_name, src_file : mt32emu_header_map
+  configure_file(input : src_file, output : file_name, copy : true)
+endforeach
+
+subdir('c_interface')

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,24 @@
+project('mt32emu', 'cpp',
+        version : '2.4.2',
+        license : 'LGPL-2.1-or-later',
+        default_options : 'b_ndebug=if-release')
+
+mt32emu_versions = meson.project_version().split('.')
+mt32emu_exports_type = 3
+
+conf_data = configuration_data()
+conf_data.set('libmt32emu_VERSION',       meson.project_version())
+conf_data.set('libmt32emu_VERSION_MAJOR', mt32emu_versions[0].to_int())
+conf_data.set('libmt32emu_VERSION_MINOR', mt32emu_versions[1].to_int())
+conf_data.set('libmt32emu_VERSION_PATCH', mt32emu_versions[2].to_int())
+conf_data.set('libmt32emu_EXPORTS_TYPE',  mt32emu_exports_type)
+
+subdir('mt32emu/src')     # all source files
+subdir('include/mt32emu') # public interface
+
+mt32emu_lib = library('mt32emu', mt32emu_sources,
+                      include_directories : 'include/mt32emu',
+                      cpp_args : ['-DMT32EMU_WITH_INTERNAL_RESAMPLER'])
+
+mt32emu_dep = declare_dependency(include_directories: 'include',
+                                 link_with: mt32emu_lib)

--- a/mt32emu/src/meson.build
+++ b/mt32emu/src/meson.build
@@ -1,0 +1,63 @@
+mt32emu_config_h_in = files('config.h.in')
+
+common_headers = [
+  'mt32emu.h',
+  'globals.h',
+  'Enumerations.h',
+  'Types.h',
+]
+cpp_headers = [
+  'File.h',
+  'FileStream.h',
+  'MidiStreamParser.h',
+  'ROMInfo.h',
+  'SampleRateConverter.h',
+  'Synth.h',
+]
+c_headers = [
+  'c_interface.h',
+  'c_types.h',
+  'cpp_interface.h',
+]
+
+# These two maps exist only, so we can generate a new directory containing
+# all the headers later on.
+#
+mt32emu_header_map = {}
+foreach header : common_headers + cpp_headers
+  mt32emu_header_map += { header : files(header) }
+endforeach
+mt32emu_c_header_map = {}
+foreach header : c_headers
+  mt32emu_c_header_map += { header : files('c_interface' / header) }
+endforeach
+
+mt32emu_sources = files(
+  'Analog.cpp',
+  'BReverbModel.cpp',
+  'File.cpp',
+  'FileStream.cpp',
+  'LA32FloatWaveGenerator.cpp',
+  'LA32Ramp.cpp',
+  'LA32WaveGenerator.cpp',
+  'MidiStreamParser.cpp',
+  'Part.cpp',
+  'Partial.cpp',
+  'PartialManager.cpp',
+  'Poly.cpp',
+  'ROMInfo.cpp',
+  'Synth.cpp',
+  'Tables.cpp',
+  'TVA.cpp',
+  'TVF.cpp',
+  'TVP.cpp',
+  'sha1/sha1.cpp',
+  'SampleRateConverter.cpp',
+  'srchelper/srctools/src/FIRResampler.cpp',
+  'srchelper/srctools/src/SincResampler.cpp',
+  'srchelper/srctools/src/IIR2xResampler.cpp',
+  'srchelper/srctools/src/LinearResampler.cpp',
+  'srchelper/srctools/src/ResamplerModel.cpp',
+  'srchelper/InternalResampler.cpp',
+  'c_interface/c_interface.cpp',
+)

--- a/readme.txt
+++ b/readme.txt
@@ -1,3 +1,18 @@
 This repository contains a Meson build definition for project mt32emu.
 
 For more information please see http://mesonbuild.com.
+
+For more information about mt32emu library see https://github.com/munt/munt.
+
+To use this wrap:
+
+    $ meson wrap install mt32emu
+    $ echo 'munt-libmt32emu*' >> subprojects/.gitignore
+
+Then create a dependency object in meson.build of your project:
+
+    mt32emu_dep = dependency('mt32emu')
+
+For meson < 0.55.0 wrap fallbacks need to be explicitly enabled:
+
+    mt32emu_dep = dependency('mt32emu', fallback : ['mt32emu', 'mt32emu_dep'])

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = munt-libmt32emu_2_4_2
+
+source_url = https://github.com/munt/munt/archive/libmt32emu_2_4_2.tar.gz
+source_filename = libmt32emu_2_4_2.tar.gz
+source_hash = 5ba49f416dc1a076ea73e2b0136ec076b0d86537b47125c104e1e8c3716efb3c
+
+[provide]
+mt32emu = mt32emu_dep


### PR DESCRIPTION
The simplest working version. Munt's project mt32emu library provides
several additional features (e.g. switching between several APIs or
replacing internal resampling library with libsoxr or libsamplerate),
but it's out of scope for the first version of meson wrap.

This buildsystem hardcodes MT32EMU_EXPORTS_TYPE to 3, which turns on
both C and C++ interface variants of the library (this is the default
behaviour of upstream buildsystem - see generated config.h file or
mt32emu README.md for the details).