### PR TITLE
Fi/version 0 47 0 compatible

### DIFF
--- a/include/mt32emu/c_interface/meson.build
+++ b/include/mt32emu/c_interface/meson.build
@@ -1,3 +1,3 @@
-foreach file_name, src_file : mt32emu_c_header_map
-  configure_file(input : src_file, output : file_name, copy : true)
+foreach src_dest : mt32emu_c_header_map
+  configure_file(input : src_dest[0], output : src_dest[1], copy : true)
 endforeach

--- a/include/mt32emu/meson.build
+++ b/include/mt32emu/meson.build
@@ -2,8 +2,8 @@ configure_file(input : mt32emu_config_h_in,
                output : 'config.h',
                configuration : conf_data)
 
-foreach file_name, src_file : mt32emu_header_map
-  configure_file(input : src_file, output : file_name, copy : true)
+foreach src_dest : mt32emu_header_map
+  configure_file(input : src_dest[0], output : src_dest[1], copy : true)
 endforeach
 
 subdir('c_interface')

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,8 @@
 project('mt32emu', 'cpp',
         version : '2.4.2',
         license : 'LGPL-2.1-or-later',
-        default_options : 'b_ndebug=if-release')
+        default_options : 'b_ndebug=if-release',
+        meson_version : '>=0.49.0')
 
 mt32emu_versions = meson.project_version().split('.')
 mt32emu_exports_type = 3
@@ -16,9 +17,12 @@ conf_data.set('libmt32emu_EXPORTS_TYPE',  mt32emu_exports_type)
 subdir('mt32emu/src')     # all source files
 subdir('include/mt32emu') # public interface
 
+mt32emu_lib_includes = include_directories('include/mt32emu')
+mt32emu_dep_includes = include_directories('include')
+
 mt32emu_lib = library('mt32emu', mt32emu_sources,
-                      include_directories : 'include/mt32emu',
+                      include_directories : mt32emu_lib_includes,
                       cpp_args : ['-DMT32EMU_WITH_INTERNAL_RESAMPLER'])
 
-mt32emu_dep = declare_dependency(include_directories: 'include',
+mt32emu_dep = declare_dependency(include_directories : mt32emu_dep_includes,
                                  link_with: mt32emu_lib)

--- a/mt32emu/src/meson.build
+++ b/mt32emu/src/meson.build
@@ -23,13 +23,13 @@ c_headers = [
 # These two maps exist only, so we can generate a new directory containing
 # all the headers later on.
 #
-mt32emu_header_map = {}
+mt32emu_header_map = []
 foreach header : common_headers + cpp_headers
-  mt32emu_header_map += { header : files(header) }
+  mt32emu_header_map += [ [ files(header), header ] ]
 endforeach
-mt32emu_c_header_map = {}
+mt32emu_c_header_map = []
 foreach header : c_headers
-  mt32emu_c_header_map += { header : files('c_interface' / header) }
+  mt32emu_c_header_map += [ [ files('c_interface' / header), header ] ]
 endforeach
 
 mt32emu_sources = files(


### PR DESCRIPTION
Reduces required meson version from 0.53.0 to 0.47.0

Inspired by:
https://github.com/dosbox-staging/dosbox-staging/issues/854#issuecomment-778892268  and https://github.com/mesonbuild/mt32emu/pull/2

I will happily squash the three commits (or drop either/both of the latter two)

