### PR TITLE
Package 2.5.0 release

### DIFF
--- a/include/mt32emu/c_interface/meson.build
+++ b/include/mt32emu/c_interface/meson.build
@@ -1,0 +1,3 @@
+foreach src_dest : mt32emu_c_header_map
+  configure_file(input : src_dest[0], output : src_dest[1], copy : true)
+endforeach

--- a/include/mt32emu/meson.build
+++ b/include/mt32emu/meson.build
@@ -1,0 +1,9 @@
+configure_file(input : mt32emu_config_h_in,
+               output : 'config.h',
+               configuration : conf_data)
+
+foreach src_dest : mt32emu_header_map
+  configure_file(input : src_dest[0], output : src_dest[1], copy : true)
+endforeach
+
+subdir('c_interface')

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,33 @@
+project('mt32emu', 'cpp',
+        version : '2.5.0',
+        license : 'LGPL-2.1-or-later',
+        default_options : 'b_ndebug=if-release',
+        meson_version : '>=0.49.0')
+
+mt32emu_versions = meson.project_version().split('.')
+mt32emu_exports_type = 3
+
+conf_data = configuration_data()
+conf_data.set('libmt32emu_VERSION',       meson.project_version())
+conf_data.set('libmt32emu_VERSION_MAJOR', mt32emu_versions[0].to_int())
+conf_data.set('libmt32emu_VERSION_MINOR', mt32emu_versions[1].to_int())
+conf_data.set('libmt32emu_VERSION_PATCH', mt32emu_versions[2].to_int())
+conf_data.set('libmt32emu_EXPORTS_TYPE',  mt32emu_exports_type)
+
+conf_data.set('libmt32emu_SHARED_DEFINITION',     '#undef MT32EMU_SHARED')
+conf_data.set('libmt32emu_WITH_VERSION_TAGGING',  0)
+conf_data.set('libmt32emu_WITH_VERSION_TAGGING',  0)
+conf_data.set('libmt32emu_RUNTIME_VERSION_CHECK', 0)
+
+subdir('mt32emu/src')     # all source files
+subdir('include/mt32emu') # public interface
+
+mt32emu_lib_includes = include_directories('include/mt32emu')
+mt32emu_dep_includes = include_directories('include')
+
+mt32emu_lib = library('mt32emu', mt32emu_sources,
+                      include_directories : mt32emu_lib_includes,
+                      cpp_args : ['-DMT32EMU_WITH_INTERNAL_RESAMPLER'])
+
+mt32emu_dep = declare_dependency(include_directories : mt32emu_dep_includes,
+                                 link_with: mt32emu_lib)

--- a/mt32emu/src/meson.build
+++ b/mt32emu/src/meson.build
@@ -1,0 +1,64 @@
+mt32emu_config_h_in = files('config.h.in')
+
+common_headers = [
+  'mt32emu.h',
+  'globals.h',
+  'Enumerations.h',
+  'Types.h',
+]
+cpp_headers = [
+  'File.h',
+  'FileStream.h',
+  'MidiStreamParser.h',
+  'ROMInfo.h',
+  'SampleRateConverter.h',
+  'Synth.h',
+]
+c_headers = [
+  'c_interface.h',
+  'c_types.h',
+  'cpp_interface.h',
+]
+
+# These two maps exist only, so we can generate a new directory containing
+# all the headers later on.
+#
+mt32emu_header_map = []
+foreach header : common_headers + cpp_headers
+  mt32emu_header_map += [ [ files(header), header ] ]
+endforeach
+mt32emu_c_header_map = []
+foreach header : c_headers
+  mt32emu_c_header_map += [ [ files('c_interface' / header), header ] ]
+endforeach
+
+mt32emu_sources = files(
+  'Analog.cpp',
+  'BReverbModel.cpp',
+  'File.cpp',
+  'FileStream.cpp',
+  'LA32FloatWaveGenerator.cpp',
+  'LA32Ramp.cpp',
+  'LA32WaveGenerator.cpp',
+  'MidiStreamParser.cpp',
+  'Part.cpp',
+  'Partial.cpp',
+  'PartialManager.cpp',
+  'Poly.cpp',
+  'ROMInfo.cpp',
+  'SampleRateConverter.cpp',
+  'Synth.cpp',
+  'Tables.cpp',
+  'TVA.cpp',
+  'TVF.cpp',
+  'TVP.cpp',
+  'VersionTagging.cpp',
+  'sha1/sha1.cpp',
+  'srchelper/srctools/src/FIRResampler.cpp',
+  'srchelper/srctools/src/SincResampler.cpp',
+  'srchelper/srctools/src/IIR2xResampler.cpp',
+  'srchelper/srctools/src/LinearResampler.cpp',
+  'srchelper/srctools/src/ResamplerModel.cpp',
+  'srchelper/InternalResampler.cpp',
+  'c_interface/c_interface.cpp',
+)

--- a/readme.txt
+++ b/readme.txt
@@ -1,3 +1,18 @@
 This repository contains a Meson build definition for project mt32emu.
 
 For more information please see http://mesonbuild.com.
+
+For more information about mt32emu library see https://github.com/munt/munt.
+
+To use this wrap:
+
+    $ meson wrap install mt32emu
+    $ echo 'munt-libmt32emu*' >> subprojects/.gitignore
+
+Then create a dependency object in meson.build of your project:
+
+    mt32emu_dep = dependency('mt32emu')
+
+For meson < 0.55.0 wrap fallbacks need to be explicitly enabled:
+
+    mt32emu_dep = dependency('mt32emu', fallback : ['mt32emu', 'mt32emu_dep'])

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = munt-libmt32emu_2_5_0
+
+source_url = https://github.com/munt/munt/archive/libmt32emu_2_5_0.tar.gz
+source_filename = libmt32emu_2_5_0.tar.gz
+source_hash = eb43864c002acedc42b304e1500f682c871ef8dabd8b5cbe492ec314a226f231
+
+[provide]
+mt32emu = mt32emu_dep


### PR DESCRIPTION
mt32emu 2.5.0 was released: https://github.com/munt/munt/releases/tag/libmt32emu_2_5_0

Changes are minimal: https://github.com/mesonbuild/mt32emu/commit/dadc0261cfdc74658d3da277aacafcbcb5ed9c54

---
Should I squash the 2.5.0 change with two commits from 2.4.2 release?